### PR TITLE
Bug fixes

### DIFF
--- a/matlab/Micromet/runThirdStageCleaningREddyProc.m
+++ b/matlab/Micromet/runThirdStageCleaningREddyProc.m
@@ -11,11 +11,14 @@ function runThirdStageCleaningREddyProc(yearIn,siteID,yearsToProcess)
 %                     for gap-filling even when outputing one year only
 %
 % Zoran Nesic               File created:       Oct 25, 2022
-%                           Last modification:  Jun 13, 2024
+%                           Last modification:  Oct 24, 2024
 %
 
 % Revisions
 %
+% Oct 24, 2024 (Zoran)
+%   - Bug fix: enclosed all the paths into "" when calling R script. That removes the bug 
+%     where the calls to R would not work if the file path included spaces.
 % Jun 13, 2024 (Zoran)
 %   - The function now passes the path to the database to the ThirdStage.R script
 %     as the first argument. 
@@ -57,7 +60,7 @@ function runThirdStageCleaningREddyProc(yearIn,siteID,yearsToProcess)
 
     % Run RScript
     % concatenate the command line argument
-    CLI_args = sprintf('"%s" --vanilla %s %s %s %i %i',pthRbin,pthThirdStageR ,strrep(pthDatabase,'\','/'),siteID,startYear,endYear);
+    CLI_args = sprintf('"%s" --vanilla "%s" "%s" %s %i %i',pthRbin,pthThirdStageR ,strrep(pthDatabase,'\','/'),siteID,startYear,endYear);
     CLI_args = [CLI_args ' 2> "' pthLogFile '" 1>&2'];
     % run the command line argument
     fprintf('Running the following command: %s\n', CLI_args);


### PR DESCRIPTION
fr_read_generic_data_file():
% Oct 24, 2024 (Zoran)
%   - Bug fix: function was not able to automatically select the proper data type ("double") when the first few rows of a column
%     were empty. It would pick the data type "char" for that column and that would be then converted to all NaNs. This
%     would then set the entire trace to NaN. The fix now forces the VariableTypes of all the selected columns to be "double".

runThirdStageCleaningREddyProc()
% Oct 24, 2024 (Zoran)
%   - Bug fix: enclosed all the paths into "" when calling R script. That removes the bug 
%     where the calls to R would not work if the file path included spaces.