### PR TITLE
Debugging basic_error_check_yml_site_config.m

### DIFF
--- a/R/database_functions/ThirdStage.R
+++ b/R/database_functions/ThirdStage.R
@@ -364,14 +364,14 @@ Storage_Correction <- function(){
   Fluxes <- config$Processing$ThirdStage$Fluxes
   Storage_Terms <- config$Processing$ThirdStage$Storage_Correction
   
-  missing_storage_term <- false
+  missing_storage_term <- FALSE
   for (flux in names(Fluxes)){
     flux_in <- unlist(Fluxes[[flux]])
     storage <- unlist(Storage_Terms[[flux]])
     # Allow script to proceed but ignore all storage correction terms
     if (sum(!is.na(input_data[[storage]]))==0){
       print(sprintf('!!! Warning !!!   No data present in %s.',storage))
-      missing_storage_term <- true
+      missing_storage_term <- TRUE
     }
   }
   
@@ -812,6 +812,7 @@ input_data <- out$input_data
 config <- out$config
 
 # Apply storage correction (if required)
+missing_storage_term <- FALSE
 if (config$Processing$ThirdStage$Storage_Correction$Run){
   out <- Storage_Correction()
   input_data <- out$input_data
@@ -846,7 +847,7 @@ if (config$Processing$ThirdStage$REddyProc$Run){
     },error = function(err){
       print('Error!!! REddyProc crashed!')
       if (config$Processing$ThirdStage$RF_GapFilling$Run){
-        config$Processing$ThirdStage$RF_GapFilling$Run <- false
+        config$Processing$ThirdStage$RF_GapFilling$Run <- FALSE
         print('Turning RF_GapFilling off')
       }
     }

--- a/matlab/Micromet/runThirdStageCleaningREddyProc.m
+++ b/matlab/Micromet/runThirdStageCleaningREddyProc.m
@@ -16,6 +16,9 @@ function fidLog = runThirdStageCleaningREddyProc(yearIn,siteID,yearsToProcess);
 
 % Revisions
 %
+% Jan 06, 2025 (Paul)
+%   - Added call to script to do some error checking on siteID_config.yml
+%     before calling ThirdStage.R
 % Dec, 2024 (Paul)
 %   - fidLog added as function output
 % Oct 24, 2024 (Zoran)
@@ -61,7 +64,7 @@ function fidLog = runThirdStageCleaningREddyProc(yearIn,siteID,yearsToProcess);
     tv_start = now; %#ok<TNOW1>
     
     % Before running ThirdStage.R, check yml file for potential errors
-    kill_3rdstage = basic_error_check_yml_site_config(siteID,yearIn,pthIni);
+    kill_3rdstage = basic_error_check_yml_site_config(siteID,yearIn,pthIni,pthBiometR);
     
     if ~kill_3rdstage
         % Run RScript


### PR DESCRIPTION
- For yml error checking script, fixed some typos, updated how some warnings are reported, fixed bugs associated with checking storage terms, biomet folderpath no longer hard coded.
- Passing biomet path from runThirdStageCleaningREddyProc to basic_error_check_yml_site_config
- Changed false to FALSE and true to TRUE in ThirdStage.R