### PR TITLE
Fix/store ml traces in new dir

### DIFF
--- a/Python/methaneGapfillML.py
+++ b/Python/methaneGapfillML.py
@@ -46,13 +46,15 @@ def main(args):
     if TEST in stages_to_run:
         fluxgapfill.test(site_path, df_all, config['models'])
     
+    ml_dir = db_path / args.year / args.site / 'Clean' / 'ThirdStage_ML'
+    os.makedirs(ml_dir, exist_ok=True)
     for model in config['models']:
         df_gapfilled = fluxgapfill.gapfill(site_path, dfs_by_year[args.year], [model])
         fch4_f = df_gapfilled['FCH4_F'].values.astype(config['dbase_metadata']['traces']['dtype'])
         fch4_f_u = df_gapfilled['FCH4_F_UNCERTAINTY'].values.astype(config['dbase_metadata']['traces']['dtype'])
 
-        fch4_f.tofile(db_path / args.year / args.site / 'Clean' / 'ThirdStage' / f'FCH4_F_ML_{model.upper()}')
-        fch4_f_u.tofile(db_path / args.year / args.site / 'Clean' / 'ThirdStage' / f'FCH4_F_ML_{model.upper()}_UNCERTAINTY')
+        fch4_f.tofile(ml_dir / f'FCH4_F_ML_{model.upper()}')
+        fch4_f_u.tofile(ml_dir / f'FCH4_F_ML_{model.upper()}_UNCERTAINTY')
 
         # Put scatter plots out? Not sure how well this would work, as the will still
         # be separated by year and model. Maybe do this after the test phase?

--- a/matlab/BIOMET/fr_automated_cleaning.m
+++ b/matlab/BIOMET/fr_automated_cleaning.m
@@ -169,7 +169,7 @@ end
 
 arg_default('stages',[1 2 3]);
 % When FCRN export is requested make sure all cleaning is done
-if ~isempty(find(stages == 4)) 
+if ~isempty(find(stages == 4))
     stages = [1 2 3 4];
 end
 


### PR DESCRIPTION
Quick change to store ML traces in their own directory. It turns out that stage `3` in `fr_automated_cleaning` does in fact delete the contents of `Clean/ThirdStage`.