### PR TITLE
Multi-fluxes + methane train/gapfill separation

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "methane-gapfill-ml"]
-	path = methane-gapfill-ml
-	url = https://github.com/mjfortier/methane-gapfill-ml.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "methane-gapfill-ml"]
+	path = methane-gapfill-ml
+	url = https://github.com/mjfortier/methane-gapfill-ml.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "Python/methane-gapfill-ml"]
+	path = Python/methane-gapfill-ml
+	url = https://github.com/mjfortier/methane-gapfill-ml.git

--- a/Python/config_files/CH4_ML_Gapfill_default.yml
+++ b/Python/config_files/CH4_ML_Gapfill_default.yml
@@ -30,7 +30,7 @@ fluxes:
     preds_trace:
       - ThirdStage/SW_IN_1_1_1
       - ThirdStage/TA_1_1_1
-      - ThirdStage/VPD_1_1_1
+      - ThirdStage/VPD_1_1_1_F
       - ThirdStage/TS_1_1_1
       - ThirdStage/SWC_1_1_1
     models:
@@ -46,7 +46,7 @@ fluxes:
     preds_trace:
       - ThirdStage/SW_IN_1_1_1
       - ThirdStage/TA_1_1_1
-      - ThirdStage/VPD_1_1_1
+      - ThirdStage/VPD_1_1_1_F
       - ThirdStage/TS_1_1_1
       - ThirdStage/SWC_1_1_1
     models:

--- a/Python/config_files/CH4_ML_Gapfill_default.yml
+++ b/Python/config_files/CH4_ML_Gapfill_default.yml
@@ -10,15 +10,80 @@ dbase_metadata:
     dtype: float32
     precision: 4
 
-methane_trace: ThirdStage/FCH4_PI_SC_JSZ_MAD_RP_uStar_orig
-predictor_traces:
-  - ThirdStage/H_PI_SC_JSZ_MAD_RP_uStar_f
-  - ThirdStage/LE_PI_SC_JSZ_MAD_RP_uStar_f
-  - ThirdStage/TA_1_1_1
-  - ThirdStage/SW_IN_1_1_1
-models:
-  - rf
-  - ann
-num_splits: 10
-split_method: artificial # chosen from ['random', 'artificial']
-imputation_method: model # chosen from ['mean', 'model']
+fluxes:
+  fch4:
+    trace: ThirdStage/FCH4_PI_SC_JSZ_MAD_RP_uStar_orig
+    preds_trace:
+      - ThirdStage/TS_1_1_1
+      - ThirdStage/TA_1_1_1
+      - ThirdStage/SWC_1_1_1
+    models:
+      - rf
+      - ann
+      - xgb
+    num_splits: 10
+    split_method: artificial # chosen from ['random', 'artificial']
+    imputation_method: model # chosen from ['mean', 'model']
+
+  nee:
+    trace: ThirdStage/NEE_PI_SC_JSZ_MAD_RP_uStar_orig
+    preds_trace:
+      - ThirdStage/SW_IN_1_1_1
+      - ThirdStage/TA_1_1_1
+      - ThirdStage/VPD_1_1_1
+      - ThirdStage/TS_1_1_1
+      - ThirdStage/SWC_1_1_1
+    models:
+      - rf
+      - ann
+      - xgb
+    num_splits: 10
+    split_method: artificial # chosen from ['random', 'artificial']
+    imputation_method: model # chosen from ['mean', 'model']
+
+  le:
+    trace: ThirdStage/LE_PI_SC_JSZ_MAD_RP_uStar_orig
+    preds_trace:
+      - ThirdStage/SW_IN_1_1_1
+      - ThirdStage/TA_1_1_1
+      - ThirdStage/VPD_1_1_1
+      - ThirdStage/TS_1_1_1
+      - ThirdStage/SWC_1_1_1
+    models:
+      - rf
+      - ann
+      - xgb
+    num_splits: 10
+    split_method: artificial # chosen from ['random', 'artificial']
+    imputation_method: model # chosen from ['mean', 'model']
+
+  h:
+    trace: ThirdStage/H_PI_SC_JSZ_MAD_RP_uStar_orig
+    preds_trace:
+      - ThirdStage/SW_IN_1_1_1
+      - ThirdStage/NETRAD_1_1_1
+      - ThirdStage/WS_1_1_1
+      - ThirdStage/TA_1_1_1
+      - ThirdStage/TS_1_1_1
+    models:
+      - rf
+      - ann
+      - xgb
+    num_splits: 10
+    split_method: artificial # chosen from ['random', 'artificial']
+    imputation_method: model # chosen from ['mean', 'model']
+
+  fno2:
+    trace: ThirdStage/H_PI_SC_JSZ_MAD_RP_uStar_orig
+    preds_trace:
+      - ThirdStage/H_PI_SC_JSZ_MAD_RP_uStar_f
+      - ThirdStage/LE_PI_SC_JSZ_MAD_RP_uStar_f
+      - ThirdStage/TA_1_1_1
+      - ThirdStage/SW_IN_1_1_1
+    models:
+      - rf
+      - ann
+      - xgb
+    num_splits: 10
+    split_method: artificial # chosen from ['random', 'artificial']
+    imputation_method: model # chosen from ['mean', 'model']

--- a/Python/methaneGapfillML.py
+++ b/Python/methaneGapfillML.py
@@ -18,36 +18,118 @@ TRAIN = 2
 TEST = 3
 GAPFILL = 4
 
+TIMESTAMP_COLUMNS = ['TIMESTAMP_START', 'TIMESTAMP_END']
+
+
 def main(args):
     db_path = Path(args.db_path)
     config = create_config(args)
 
     for flux_name, flux_config in config['fluxes'].items():
-        print(f"\n{'='*5} {flux_name.upper()} {'='*5}")
+        # to overwrite the default by ignoring some fluxes, leave the flux config empty
+        # e.g. fluxes:
+        #       |-> fch4:           # here, fch4 will be ignored
+        #       |-> nee:
+        #             trace:
+        #             preds_trace:  # and so on
+        if flux_config is None:
+            print(f"Skipping {flux_name.upper()}...")
+            continue
+
+        flux_label = flux_name.upper()
+        print(f"\n{'-'*5} {flux_name.upper()} {'-'*5}")
         dfs_by_year = read_database_traces(db_path, config, flux_name, flux_config)
-        stages_to_run = get_stages_to_run(db_path, dfs_by_year, flux_name, flux_config)
+        if not dfs_by_year:
+            raise RuntimeError(
+                f'No readable yearly data found for flux "{flux_name}" '
+                f'using trace "{flux_config["trace"]}".'
+            )
+        site_path = get_site_path(db_path, args.site, flux_name)
+        stages_to_run = get_stages_to_run(
+            site_path, dfs_by_year, flux_config, flux_label, config['mode']
+        )
         df_all = pd.concat(list(dfs_by_year.values()), axis=0).sort_index()
-        site_path = db_path / 'methane_gapfill_ml' / args.site / flux_name
 
         if PREPROCESS in stages_to_run:
-            setup_and_preprocess(site_path, dfs_by_year, flux_config)
+            setup_and_preprocess(site_path, dfs_by_year, flux_config, flux_label)
         
         if TRAIN in stages_to_run:
             predictors = [str(Path(p).stem) for p in flux_config['preds_trace']]
-            fluxgapfill.train(site_path, df_all, flux_config['models'], predictors)
+            fluxgapfill.train(
+                site_path, df_all, flux_config['models'], predictors,
+                target=flux_label
+            )
 
         if TEST in stages_to_run:
-            fluxgapfill.test(site_path, df_all, flux_config['models'])
+            fluxgapfill.test(site_path, df_all, flux_config['models'], target=flux_label)
         
         ml_dir = db_path / args.year / args.site / 'Clean' / 'ThirdStage_ML' / flux_name
         os.makedirs(ml_dir, exist_ok=True)
         for model in flux_config['models']:
-            df_gapfilled = fluxgapfill.gapfill(site_path, dfs_by_year[args.year], [model])
-            flux_f = df_gapfilled[f'{flux_name.upper()}_F'].values.astype(config['dbase_metadata']['traces']['dtype'])
-            flux_f_u = df_gapfilled[f'{flux_name.upper()}_F_UNCERTAINTY'].values.astype(config['dbase_metadata']['traces']['dtype'])
+            df_gapfilled = fluxgapfill.gapfill(
+                site_path, dfs_by_year[args.year], [model],
+                target=flux_label, output_prefix=flux_label
+            )
+            flux_f = df_gapfilled[f'{flux_label}_F'].values.astype(config['dbase_metadata']['traces']['dtype'])
+            flux_f_u = df_gapfilled[f'{flux_label}_F_UNCERTAINTY'].values.astype(config['dbase_metadata']['traces']['dtype'])
 
-            flux_f.tofile(ml_dir / f'{flux_name.upper()}_F_ML_{model.upper()}')
-            flux_f_u.tofile(ml_dir / f'{flux_name.upper()}_F_ML_{model.upper()}_UNCERTAINTY')
+            flux_f.tofile(ml_dir / f'{flux_label}_F_ML_{model.upper()}')
+            flux_f_u.tofile(ml_dir / f'{flux_label}_F_ML_{model.upper()}_UNCERTAINTY')
+
+        print(f"{'-'*(len(flux_name)+12)}")
+
+def deep_merge(base, override):
+    """Recursively merges override into base and returns base."""
+    for key, value in override.items():
+        if isinstance(value, dict) and isinstance(base.get(key), dict):
+            deep_merge(base[key], value)
+        else:
+            base[key] = value
+    return base
+
+
+def hash_df_columns(df, columns):
+    return hashlib.sha256(df[columns].to_json().encode('utf-8')).hexdigest()
+
+
+def build_preprocess_signature(flux_config):
+    return {
+        'trace': flux_config['trace'],
+        'split_method': flux_config['split_method'],
+        'num_splits': flux_config['num_splits'],
+    }
+
+
+def build_run_info(dfs_by_year, flux_config, flux_label):
+    preprocess_columns = TIMESTAMP_COLUMNS + [flux_label]
+    return {
+        'preprocess_config': build_preprocess_signature(flux_config),
+        'preprocess_hashes': {
+            year: hash_df_columns(df, preprocess_columns)
+            for year, df in dfs_by_year.items()
+        },
+    }
+
+
+def write_run_info(site_path, run_info):
+    os.makedirs(site_path, exist_ok=True)
+    with open(site_path / 'run_info.json', 'w') as f:
+        json.dump(run_info, f)
+
+
+def get_site_path(db_path, site, flux_name):
+    return db_path / 'methane_gapfill_ml' / site / flux_name
+
+
+def has_complete_indices(site_path, num_splits):
+    if not (site_path / 'indices' / 'test.npy').exists():
+        return False
+    for i in range(num_splits):
+        if not (site_path / 'indices' / f'train{i}.npy').exists():
+            return False
+        if not (site_path / 'indices' / f'val{i}.npy').exists():
+            return False
+    return True
 
 
 def create_config(args) -> dict:
@@ -64,46 +146,44 @@ def create_config(args) -> dict:
     custom_config_path = trace_analysis_ini_path  / 'CH4_ML_Gapfill.yml'
     if os.path.exists(custom_config_path):
         with open(custom_config_path, 'r') as custom_ml_comfig_file:
-            config.update(yaml.safe_load(custom_ml_comfig_file))
+            custom_config = yaml.safe_load(custom_ml_comfig_file)
+            deep_merge(config, custom_config)
     
     site_config_path = trace_analysis_ini_path / site / 'CH4_ML_Gapfill.yml'
     if os.path.exists(site_config_path):
         with open(site_config_path, 'r') as site_ml_config_file:
-            config.update(yaml.safe_load(site_ml_config_file))
+            site_config = yaml.safe_load(site_ml_config_file)
+            deep_merge(config, site_config)
+
+    config['mode'] = args.mode
     
     return config
     
 
-def setup_and_preprocess(site_path, dfs_by_year, flux_config):
+def setup_and_preprocess(site_path, dfs_by_year, flux_config, flux_label):
     '''Creates the run directory and caches the config as JSON, then runs preprocess'''
     os.makedirs(site_path / 'indices')
-    hash_df = lambda df: hashlib.sha256(df.to_json().encode('utf-8')).hexdigest()
-    hashes = {year: hash_df(df) for year, df in dfs_by_year.items()}
-    with open(site_path / 'run_info.json', 'w') as f:
-        json.dump({ 'config': flux_config, 'hashes': hashes }, f)
+    write_run_info(site_path, build_run_info(dfs_by_year, flux_config, flux_label))
 
     all_df = pd.concat(list(dfs_by_year.values()), axis=0).sort_index()
-    fluxgapfill.preprocess(site_path, all_df, split_method=flux_config['split_method'], n_train=flux_config['num_splits'])
+    fluxgapfill.preprocess(
+        site_path, all_df, target=flux_label,
+        split_method=flux_config['split_method'], n_train=flux_config['num_splits']
+    )
 
 
-def get_stages_to_run(db_path, dfs_by_year, flux_name, flux_config) -> list:
-    site_path = db_path / 'methane_gapfill_ml' / args.site / flux_name
+def get_stages_to_run(site_path, dfs_by_year, flux_config, flux_label, mode) -> list:
     stages = [PREPROCESS, TRAIN, TEST, GAPFILL]
+    current_run_info = build_run_info(dfs_by_year, flux_config, flux_label)
 
     # Preprocess
     try:
         with open(site_path / 'run_info.json', 'r') as f:
             run_info = json.load(f)
-        
-        hash_df = lambda df: hashlib.sha256(df.to_json().encode('utf-8')).hexdigest()
-        hashes = {year: hash_df(df) for year, df in dfs_by_year.items()}
-        assert run_info['config'] == flux_config
-        assert run_info['hashes'] == hashes
 
-        for i in range(flux_config['num_splits']):
-            assert os.path.exists(site_path / 'indices' / f'train{i}.npy')
-            assert os.path.exists(site_path / 'indices' / f'val{i}.npy')
-        assert os.path.exists(site_path / 'indices' / 'test.npy')
+        assert run_info['preprocess_config'] == current_run_info['preprocess_config']
+        assert run_info['preprocess_hashes'] == current_run_info['preprocess_hashes']
+        assert has_complete_indices(site_path, flux_config['num_splits'])
         stages.remove(PREPROCESS)
     except Exception as e:
         # Data has changed, or some other fundamental part of the config.
@@ -112,15 +192,21 @@ def get_stages_to_run(db_path, dfs_by_year, flux_name, flux_config) -> list:
             shutil.rmtree(site_path)
         print('Running pipeline from preprocess')
         return stages
-    
+
     # Train
-    try:
-        for model in flux_config['models']:
-            assert is_train_run_complete(site_path, model, flux_config['num_splits'])
-        stages.remove(TRAIN)
-    except Exception as e:
-        print('Running pipeline from train')
-        return stages
+    train_complete = all(
+        is_train_run_complete(site_path, model, flux_config['num_splits'])
+        for model in flux_config['models']
+    )
+    stages.remove(TRAIN)
+
+    if not train_complete:
+        if mode == 'full':
+            print('Running pipeline from train')
+            return stages
+        raise RuntimeError(
+            f'Gapfill mode requested, but trained models are missing for flux "{flux_label}".'
+        )
 
     # Test
     try:
@@ -133,6 +219,7 @@ def get_stages_to_run(db_path, dfs_by_year, flux_name, flux_config) -> list:
         return stages
     
     return stages
+
 
 def is_train_run_complete(path, model, num_splits) -> bool:
     '''Checks if a given site has a full set of trained models'''
@@ -187,18 +274,18 @@ def read_database_trace_by_year(db_path, year, config, flux_name, flux_config) -
         trace_values = np.fromfile(db_path / year / config['site'] / 'Clean' / trace_path, dtype=trace_dtype)
         df[trace_name] = trace_values
 
-    # Methane
-    methane_values = np.fromfile(db_path / year / config['site'] / 'Clean' / Path(flux_config['trace']), dtype=trace_dtype)
-    df[flux_name.upper()] = methane_values
+    # Target flux
+    flux_values = np.fromfile(db_path / year / config['site'] / 'Clean' / Path(flux_config['trace']), dtype=trace_dtype)
+    df[flux_name.upper()] = flux_values
     return df 
 
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser()
-    parser.add_argument("--site", type=str, required=True)
-    parser.add_argument("--year", type=str, required=True)
-    parser.add_argument("--db_path", type=str, required=True)
-    # parser.add_argument("--train", type=bool, required=True)
+    parser.add_argument('--site', type=str, required=True)
+    parser.add_argument('--year', type=str, required=True)
+    parser.add_argument('--db_path', type=str, required=True)
+    parser.add_argument('--mode', type=str, choices=['full', 'gapfill'], required=True)
     args = parser.parse_args()
 
     main(args)

--- a/Python/methaneGapfillML.py
+++ b/Python/methaneGapfillML.py
@@ -134,59 +134,6 @@ def get_stages_to_run(db_path, dfs_by_year, flux_name, flux_config) -> list:
     
     return stages
 
-"""
-def get_stages_to_run(db_path, dfs_by_year, config) -> list:
-    '''Smart procedure for determining how much of the pipeline needs to
-       be rerun for a given site. Returns a list of stages to run
-    '''
-    stages = [PREPROCESS, TRAIN, TEST, GAPFILL]
-    site_path = db_path / 'methane_gapfill_ml' / args.site
-
-    # Preprocess
-    try:
-        with open(site_path / 'run_info.json', 'r') as f:
-            run_info = json.load(f)
-        
-        hash_df = lambda df: hashlib.sha256(df.to_json().encode('utf-8')).hexdigest()
-        hashes = {year: hash_df(df) for year, df in dfs_by_year.items()}
-        assert run_info['config'] == config
-        assert run_info['hashes'] == hashes
-
-        for i in range(config['num_splits']):
-            assert os.path.exists(site_path / 'indices' / f'train{i}.npy')
-            assert os.path.exists(site_path / 'indices' / f'val{i}.npy')
-        assert os.path.exists(site_path / 'indices' / 'test.npy')
-        stages.remove(PREPROCESS)
-    except Exception as e:
-        # Data has changed, or some other fundamental part of the config.
-        # Scrap the entire directory and start over.
-        if os.path.exists(site_path):
-            shutil.rmtree(site_path)
-        print('Running pipeline from preprocess')
-        return stages
-
-    # Train
-    try:
-        for model in config['models']:
-            assert is_train_run_complete(site_path, model, config['num_splits'])
-        stages.remove(TRAIN)
-    except Exception as e:
-        print('Running pipeline from train')
-        return stages
-
-    # Test
-    try:
-        for model in config['models']:
-            assert os.path.exists(site_path / 'models' / model / 'test_metrics.csv')
-            assert os.path.exists(site_path / 'models' / model / 'test_predictions.csv')
-        stages.remove(TEST)
-    except Exception as e:
-        print('Running pipeline from test')
-        return stages
-    
-    return stages
-"""
-
 def is_train_run_complete(path, model, num_splits) -> bool:
     '''Checks if a given site has a full set of trained models'''
     for i in range(num_splits):

--- a/Python/methaneGapfillML.py
+++ b/Python/methaneGapfillML.py
@@ -22,30 +22,32 @@ def main(args):
     db_path = Path(args.db_path)
     config = create_config(args)
 
-    dfs_by_year = read_database_traces(db_path, config)
-    stages_to_run = get_stages_to_run(db_path, dfs_by_year, config)
-    df_all = pd.concat(list(dfs_by_year.values()), axis=0).sort_index()
-    site_path = db_path / 'methane_gapfill_ml' / args.site
+    for flux_name, flux_config in config['fluxes'].items():
+        print(f"\n{'='*5} {flux_name.upper()} {'='*5}")
+        dfs_by_year = read_database_traces(db_path, config, flux_name, flux_config)
+        stages_to_run = get_stages_to_run(db_path, dfs_by_year, flux_name, flux_config)
+        df_all = pd.concat(list(dfs_by_year.values()), axis=0).sort_index()
+        site_path = db_path / 'methane_gapfill_ml' / args.site / flux_name
 
-    if PREPROCESS in stages_to_run:
-        setup_and_preprocess(site_path, dfs_by_year, config)
-    
-    if TRAIN in stages_to_run:
-        predictors = [str(Path(p).stem) for p in config['predictor_traces']]
-        fluxgapfill.train(site_path, df_all, config['models'], predictors)
+        if PREPROCESS in stages_to_run:
+            setup_and_preprocess(site_path, dfs_by_year, flux_config)
+        
+        if TRAIN in stages_to_run:
+            predictors = [str(Path(p).stem) for p in flux_config['preds_trace']]
+            fluxgapfill.train(site_path, df_all, flux_config['models'], predictors)
 
-    if TEST in stages_to_run:
-        fluxgapfill.test(site_path, df_all, config['models'])
-    
-    ml_dir = db_path / args.year / args.site / 'Clean' / 'ThirdStage_ML'
-    os.makedirs(ml_dir, exist_ok=True)
-    for model in config['models']:
-        df_gapfilled = fluxgapfill.gapfill(site_path, dfs_by_year[args.year], [model])
-        fch4_f = df_gapfilled['FCH4_F'].values.astype(config['dbase_metadata']['traces']['dtype'])
-        fch4_f_u = df_gapfilled['FCH4_F_UNCERTAINTY'].values.astype(config['dbase_metadata']['traces']['dtype'])
+        if TEST in stages_to_run:
+            fluxgapfill.test(site_path, df_all, flux_config['models'])
+        
+        ml_dir = db_path / args.year / args.site / 'Clean' / 'ThirdStage_ML' / flux_name
+        os.makedirs(ml_dir, exist_ok=True)
+        for model in flux_config['models']:
+            df_gapfilled = fluxgapfill.gapfill(site_path, dfs_by_year[args.year], [model])
+            flux_f = df_gapfilled[f'{flux_name.upper()}_F'].values.astype(config['dbase_metadata']['traces']['dtype'])
+            flux_f_u = df_gapfilled[f'{flux_name.upper()}_F_UNCERTAINTY'].values.astype(config['dbase_metadata']['traces']['dtype'])
 
-        fch4_f.tofile(ml_dir / f'FCH4_F_ML_{model.upper()}')
-        fch4_f_u.tofile(ml_dir / f'FCH4_F_ML_{model.upper()}_UNCERTAINTY')
+            flux_f.tofile(ml_dir / f'{flux_name.upper()}_F_ML_{model.upper()}')
+            flux_f_u.tofile(ml_dir / f'{flux_name.upper()}_F_ML_{model.upper()}_UNCERTAINTY')
 
 
 def create_config(args) -> dict:
@@ -72,18 +74,67 @@ def create_config(args) -> dict:
     return config
     
 
-def setup_and_preprocess(site_path, dfs_by_year, config):
+def setup_and_preprocess(site_path, dfs_by_year, flux_config):
     '''Creates the run directory and caches the config as JSON, then runs preprocess'''
     os.makedirs(site_path / 'indices')
     hash_df = lambda df: hashlib.sha256(df.to_json().encode('utf-8')).hexdigest()
     hashes = {year: hash_df(df) for year, df in dfs_by_year.items()}
     with open(site_path / 'run_info.json', 'w') as f:
-        json.dump({ 'config': config, 'hashes': hashes }, f)
+        json.dump({ 'config': flux_config, 'hashes': hashes }, f)
 
     all_df = pd.concat(list(dfs_by_year.values()), axis=0).sort_index()
-    fluxgapfill.preprocess(site_path, all_df, split_method=config['split_method'], n_train=config['num_splits'])
+    fluxgapfill.preprocess(site_path, all_df, split_method=flux_config['split_method'], n_train=flux_config['num_splits'])
 
 
+def get_stages_to_run(db_path, dfs_by_year, flux_name, flux_config) -> list:
+    site_path = db_path / 'methane_gapfill_ml' / args.site / flux_name
+    stages = [PREPROCESS, TRAIN, TEST, GAPFILL]
+
+    # Preprocess
+    try:
+        with open(site_path / 'run_info.json', 'r') as f:
+            run_info = json.load(f)
+        
+        hash_df = lambda df: hashlib.sha256(df.to_json().encode('utf-8')).hexdigest()
+        hashes = {year: hash_df(df) for year, df in dfs_by_year.items()}
+        assert run_info['config'] == flux_config
+        assert run_info['hashes'] == hashes
+
+        for i in range(flux_config['num_splits']):
+            assert os.path.exists(site_path / 'indices' / f'train{i}.npy')
+            assert os.path.exists(site_path / 'indices' / f'val{i}.npy')
+        assert os.path.exists(site_path / 'indices' / 'test.npy')
+        stages.remove(PREPROCESS)
+    except Exception as e:
+        # Data has changed, or some other fundamental part of the config.
+        # Scrap the entire directory and start over.
+        if os.path.exists(site_path):
+            shutil.rmtree(site_path)
+        print('Running pipeline from preprocess')
+        return stages
+    
+    # Train
+    try:
+        for model in flux_config['models']:
+            assert is_train_run_complete(site_path, model, flux_config['num_splits'])
+        stages.remove(TRAIN)
+    except Exception as e:
+        print('Running pipeline from train')
+        return stages
+
+    # Test
+    try:
+        for model in flux_config['models']:
+            assert os.path.exists(site_path / 'models' / model / 'test_metrics.csv')
+            assert os.path.exists(site_path / 'models' / model / 'test_predictions.csv')
+        stages.remove(TEST)
+    except Exception as e:
+        print('Running pipeline from test')
+        return stages
+    
+    return stages
+
+"""
 def get_stages_to_run(db_path, dfs_by_year, config) -> list:
     '''Smart procedure for determining how much of the pipeline needs to
        be rerun for a given site. Returns a list of stages to run
@@ -134,7 +185,7 @@ def get_stages_to_run(db_path, dfs_by_year, config) -> list:
         return stages
     
     return stages
-
+"""
 
 def is_train_run_complete(path, model, num_splits) -> bool:
     '''Checks if a given site has a full set of trained models'''
@@ -146,7 +197,7 @@ def is_train_run_complete(path, model, num_splits) -> bool:
     return True
 
 
-def read_database_traces(db_path, config) -> dict:
+def read_database_traces(db_path, config, flux_name, flux_config) -> dict:
     """Reads binary data for a given site and returns a pandas DataFrame.
     Args:
         db_path (str): Path to the Database directory
@@ -156,19 +207,22 @@ def read_database_traces(db_path, config) -> dict:
     database_years = [d for d in os.listdir(db_path) if d.isnumeric()]
     for year in database_years:
         try:
-            dfs_by_year[year] = read_database_trace_by_year(db_path, year, config)
-        except FileNotFoundError as _:
-            print(f'Variables not found for year {year}. Skipping...')
+            dfs_by_year[year] = read_database_trace_by_year(db_path, year, config, flux_name, flux_config)
+        except FileNotFoundError as e:
+            print(f'Variables not found for year {year}. Skipping... but also: {e}')
     return dfs_by_year
 
 
-def read_database_trace_by_year(db_path, year, config) -> pd.DataFrame:
-    """Reads binary data for a given site and year, and returns a pandas DataFrame.
+
+def read_database_trace_by_year(db_path, year, config, flux_name, flux_config) -> pd.DataFrame:
+    """
+    Reads binary data for a given site and year, and returns a pandas DataFrame.
     Args:
         db_path (str): Path to the Database directory
         year (int): The year read in the Database
         config (dict): Configuration dictionary (contains the site)
     """
+    
     # Timestamps
     ts_cfg = config['dbase_metadata']['timestamp'] # for brevity
     timestamp_raw = np.fromfile(db_path / year / config['site'] / 'Clean' / 'SecondStage' / ts_cfg['name'], dtype=ts_cfg['dtype'])
@@ -180,16 +234,16 @@ def read_database_trace_by_year(db_path, year, config) -> pd.DataFrame:
 
     # Predictor traces
     trace_dtype = config['dbase_metadata']['traces']['dtype']
-    for trace in config['predictor_traces']:
+    for trace in flux_config['preds_trace']:
         trace_path = Path(trace)
         trace_name = trace_path.stem
         trace_values = np.fromfile(db_path / year / config['site'] / 'Clean' / trace_path, dtype=trace_dtype)
         df[trace_name] = trace_values
 
     # Methane
-    methane_values = np.fromfile(db_path / year / config['site'] / 'Clean' / Path(config['methane_trace']), dtype=trace_dtype)
-    df['FCH4'] = methane_values
-    return df
+    methane_values = np.fromfile(db_path / year / config['site'] / 'Clean' / Path(flux_config['trace']), dtype=trace_dtype)
+    df[flux_name.upper()] = methane_values
+    return df 
 
 
 if __name__ == "__main__":
@@ -197,6 +251,7 @@ if __name__ == "__main__":
     parser.add_argument("--site", type=str, required=True)
     parser.add_argument("--year", type=str, required=True)
     parser.add_argument("--db_path", type=str, required=True)
+    # parser.add_argument("--train", type=bool, required=True)
     args = parser.parse_args()
 
     main(args)

--- a/matlab/Micromet/runThirdStageCleaningMethaneGapfillML.m
+++ b/matlab/Micromet/runThirdStageCleaningMethaneGapfillML.m
@@ -7,12 +7,23 @@ function fidLog = runThirdStageCleaningMethaneGapfillML(yearIn,siteID);
 % Arguments
 %   yearIn          - year to clean
 %   siteID          - site ID as a char
+%   TrainFill       - 1 runs all stages including training
+%                   - 0 uses an existing model and just gapfill
+    
+    % use existing model by default
+    % else call train_ML_gapfill(:_,:_) in your main_<siteID>.m
+    arg_default('TrainFill', 0); 
     
     pythonPath = findBiometPythonPath;
     scriptPath = fullfile(pythonPath, 'methaneGapfillML.py');
     databasePath = findDatabasePath;
-    command = sprintf('python "%s" --site %s --year %s --db_path %s', ...
-                      scriptPath, siteID, num2str(yearIn), databasePath);
+    if TrainFill == 1
+        command = sprintf('/opt/anaconda3/envs/biomet/bin/python "%s" --site %s --year %s --db_path %s --mode %s', ...
+                          scriptPath, siteID, num2str(yearIn), databasePath, 'full');
+    elseif TrainFill == 0
+        command = sprintf('/opt/anaconda3/envs/biomet/bin/python "%s" --site %s --year %s --db_path %s --mode %s', ...
+                          scriptPath, siteID, num2str(yearIn), databasePath, 'gapfill');
+    end
     status = system(command, '-echo');
    
 end

--- a/matlab/Micromet/train_ML_gapfill.m
+++ b/matlab/Micromet/train_ML_gapfill.m
@@ -1,0 +1,22 @@
+function train_ML_gapfill(Years,Sites)
+% funtion to call full run, including training of ML gapfilling pipeline
+% if a model has already been trained, this can be skipped and gapfilling can be run using fr_automated_cleaning(Years,Sites,9)
+
+numOfYears = length(Years);
+numOfSites = length(Sites);
+
+for cntSites = 1:numOfSites
+    siteID = upper(char(Sites(cntSites)));
+    
+    for cntYears = 1:numOfYears
+        yy = Years(cntYears);
+        yy_str = num2str(yy(1));
+
+        %------------------------------------------------------------------
+        % 9th stage is the methane-gapfill-ml python pipeline
+        %------------------------------------------------------------------
+        disp(['============== Running full ML gapfilling pipeline including training: ' siteID ' ' yy_str ' ==============']);
+        runThirdStageCleaningMethaneGapfillML_test(yy, siteID, 1);
+        fprintf('============== End of cleaning stage 9 =============\n'); 
+    end
+end


### PR DESCRIPTION
Fix issues in previous multi-flux methane gap-filling update.

Also add `train_ML_gapfill.m`, a MATLAB script that allows either training + gap-filling or gap-filling only (default behavior when called from `fr_automated_cleaning.m` at stage 9).

Since changes have been made to the `methane-gapfill-ml` submodule, please do not only do `git pull` but rather 
```
git pull
git submodule update --init --recursive
```