### PR TITLE
Quick fix on last training/gapfilling separation commit

### DIFF
--- a/Python/methaneGapfillML.py
+++ b/Python/methaneGapfillML.py
@@ -176,7 +176,20 @@ def get_stages_to_run(site_path, dfs_by_year, flux_config, flux_label, mode) -> 
     stages = [PREPROCESS, TRAIN, TEST, GAPFILL]
     current_run_info = build_run_info(dfs_by_year, flux_config, flux_label)
 
-    # Preprocess
+    if mode == 'gapfill':
+        missing_models = [
+            model for model in flux_config['models']
+            if not is_gapfill_run_complete(site_path, model, flux_config['num_splits'])
+        ]
+        if missing_models:
+            missing_models_str = ', '.join(missing_models)
+            raise RuntimeError(
+                f'Gapfill mode requested, but trained/tested models are missing for flux "{flux_label}" '
+                f'(models: {missing_models_str}). Use train_ML_gapfill.m to train the model.'
+            )
+        return [GAPFILL]
+
+    # --- Preprocess ---
     try:
         with open(site_path / 'run_info.json', 'r') as f:
             run_info = json.load(f)
@@ -193,22 +206,19 @@ def get_stages_to_run(site_path, dfs_by_year, flux_config, flux_label, mode) -> 
         print('Running pipeline from preprocess')
         return stages
 
-    # Train
+    # --- Train ---
     train_complete = all(
         is_train_run_complete(site_path, model, flux_config['num_splits'])
         for model in flux_config['models']
     )
-    stages.remove(TRAIN)
 
     if not train_complete:
-        if mode == 'full':
-            print('Running pipeline from train')
-            return stages
-        raise RuntimeError(
-            f'Gapfill mode requested, but trained models are missing for flux "{flux_label}".'
-        )
+        print('Running pipeline from train')
+        return stages
+    else:
+        stages.remove(TRAIN)
 
-    # Test
+    # --- Test ---
     try:
         for model in flux_config['models']:
             assert os.path.exists(site_path / 'models' / model / 'test_metrics.csv')
@@ -222,13 +232,21 @@ def get_stages_to_run(site_path, dfs_by_year, flux_config, flux_label, mode) -> 
 
 
 def is_train_run_complete(path, model, num_splits) -> bool:
-    '''Checks if a given site has a full set of trained models'''
-    for i in range(num_splits):
-        if not os.path.exists(path / 'models' / model / f'{model}{i}.pkl'):
-            return False
-    if not os.path.exists(path / 'models' / model / 'val_metrics.csv'):
-        return False
-    return True
+    """Checks if a given site has a full set of trained models"""
+    model_dir = path / 'models' / model
+    return (
+        all(os.path.exists(model_dir / f'{model}{i}.pkl') for i in range(num_splits))
+        and os.path.exists(model_dir / 'val_metrics.csv')
+    )
+
+
+def is_gapfill_run_complete(path, model, num_splits) -> bool:
+    """Checks if a model has all artifacts required for gapfill-only runs."""
+    model_dir = path / 'models' / model
+    return (
+        is_train_run_complete(path, model, num_splits)
+        and os.path.exists(model_dir / 'scale.json')
+    )
 
 
 def read_database_traces(db_path, config, flux_name, flux_config) -> dict:

--- a/Python/methaneGapfillML.py
+++ b/Python/methaneGapfillML.py
@@ -173,7 +173,6 @@ def setup_and_preprocess(site_path, dfs_by_year, flux_config, flux_label):
 
 
 def get_stages_to_run(site_path, dfs_by_year, flux_config, flux_label, mode) -> list:
-    stages = [PREPROCESS, TRAIN, TEST, GAPFILL]
     current_run_info = build_run_info(dfs_by_year, flux_config, flux_label)
 
     if mode == 'gapfill':
@@ -189,46 +188,48 @@ def get_stages_to_run(site_path, dfs_by_year, flux_config, flux_label, mode) -> 
             )
         return [GAPFILL]
 
-    # --- Preprocess ---
-    try:
-        with open(site_path / 'run_info.json', 'r') as f:
-            run_info = json.load(f)
+    elif mode == 'full': 
+        valid_stages = [PREPROCESS, TRAIN, TEST, GAPFILL]
+        # --- Preprocess ---
+        try:
+            with open(site_path / 'run_info.json', 'r') as f:
+                run_info = json.load(f)
+            assert run_info['preprocess_config'] == current_run_info['preprocess_config']
+            assert run_info['preprocess_hashes'] == current_run_info['preprocess_hashes']
+            assert has_complete_indices(site_path, flux_config['num_splits'])
+            valid_stages.remove(PREPROCESS)
+        except Exception as _:
+            if os.path.exists(site_path):
+                shutil.rmtree(site_path)
+            print('Running pipeline from preprocess')
+            return valid_stages
+        
+        # --- Train ---
+        try:
+            for model in flux_config['models']:
+                model_dir = site_path / 'models' / model
+                for i in range(flux_config['num_splits']):
+                    assert os.path.exists(model_dir / f'{model}{i}.pkl')
+                assert os.path.exists(model_dir / 'val_metrics.csv')
+            valid_stages.remove(TRAIN)
+        except Exception as _:
+            print('Running pipeline from train')
+            return valid_stages
+        
+        # --- Test ---
+        try:
+            for model in flux_config['models']:
+                assert os.path.exists(site_path / 'models' / model / 'test_metrics.csv')
+                assert os.path.exists(site_path / 'models' / model / 'test_predictions.csv')
+            valid_stages.remove(TEST)
+        except Exception as _:
+            print('Running pipeline from test')
+            return valid_stages
 
-        assert run_info['preprocess_config'] == current_run_info['preprocess_config']
-        assert run_info['preprocess_hashes'] == current_run_info['preprocess_hashes']
-        assert has_complete_indices(site_path, flux_config['num_splits'])
-        stages.remove(PREPROCESS)
-    except Exception as e:
-        # Data has changed, or some other fundamental part of the config.
-        # Scrap the entire directory and start over.
-        if os.path.exists(site_path):
-            shutil.rmtree(site_path)
-        print('Running pipeline from preprocess')
-        return stages
-
-    # --- Train ---
-    train_complete = all(
-        is_train_run_complete(site_path, model, flux_config['num_splits'])
-        for model in flux_config['models']
-    )
-
-    if not train_complete:
-        print('Running pipeline from train')
-        return stages
-    else:
-        stages.remove(TRAIN)
-
-    # --- Test ---
-    try:
-        for model in flux_config['models']:
-            assert os.path.exists(site_path / 'models' / model / 'test_metrics.csv')
-            assert os.path.exists(site_path / 'models' / model / 'test_predictions.csv')
-        stages.remove(TEST)
-    except Exception as e:
-        print('Running pipeline from test')
-        return stages
+        return valid_stages
     
-    return stages
+    else:
+        raise ValueError(f"The mode {mode} is invalid. Please use either 'full' or 'gapfill'.")
 
 
 def is_train_run_complete(path, model, num_splits) -> bool:

--- a/matlab/Micromet/runThirdStageCleaningMethaneGapfillML.m
+++ b/matlab/Micromet/runThirdStageCleaningMethaneGapfillML.m
@@ -1,5 +1,5 @@
-function fidLog = runThirdStageCleaningMethaneGapfillML(yearIn,siteID);
-% runThirdStageCleaningMethaneGapfillML(yearIn,siteID)
+function fidLog = runThirdStageCleaningMethaneGapfillML(yearIn,siteID,TrainFill);
+% runThirdStageCleaningMethaneGapfillML(yearIn,siteID,TrainFill)
 %
 % This function invokes Micromet third-stage cleaning Python pipeline.
 % Usually, it's called by fr_automated_cleaning()

--- a/matlab/Micromet/train_ML_gapfill.m
+++ b/matlab/Micromet/train_ML_gapfill.m
@@ -3,19 +3,15 @@ function train_ML_gapfill(Years,siteID)
 % if a model has already been trained, this can be skipped and gapfilling can be run using fr_automated_cleaning(Years,Sites,9)
 
 numOfYears = length(Years);
-numOfSites = length(Sites);
-
-for cntSites = 1:numOfSites
     
-    for cntYears = 1:numOfYears
-        yy = Years(cntYears);
-        yy_str = num2str(yy(1));
+for cntYears = 1:numOfYears
+    yy = Years(cntYears);
+    yy_str = num2str(yy(1));
 
-        %------------------------------------------------------------------
-        % 9th stage is the methane-gapfill-ml python pipeline
-        %------------------------------------------------------------------
-        disp(['============== Running full ML gapfilling pipeline including training: ' siteID ' ' yy_str ' ==============']);
-        runThirdStageCleaningMethaneGapfillML_test(yy,siteID,1);
-        fprintf('============== End of cleaning stage 9 =============\n'); 
-    end
+    %------------------------------------------------------------------
+    % 9th stage is the methane-gapfill-ml python pipeline
+    %------------------------------------------------------------------
+    disp(['============== Running full ML gapfilling pipeline including training: ' siteID ' ' yy_str ' ==============']);
+    runThirdStageCleaningMethaneGapfillML(yy,siteID,1);
+    fprintf('============== End of cleaning stage 9 =============\n'); 
 end


### PR DESCRIPTION
Also, I forgot to mention this in the previous commits but here's an example of how to configure the new methaneGapfillML YAML config:

```
dbase_metadata:
  timestamp: 
    name: clean_tv
    dtype: float64
    precision: 8
    base: 719529
    base_unit: D
    resolution: 30min
  traces:
    dtype: float32
    precision: 4

fluxes:
  fch4:
    trace: ThirdStage/FCH4_PI_SC_JSZ_MAD_RP_uStar_orig
    preds_trace:
      - ThirdStage/TS_1_1_1
      - ThirdStage/TA_1_1_1
      - ThirdStage/SWC_1_1_1
    models:
      - xgb
    num_splits: 10
    split_method: artificial 
    imputation_method: model 

  nee:
  le:
  h:
  fno2:
  ```

Only FCH4 would run.