### PR TITLE
Update fr_read_generic_data_file.m

### DIFF
--- a/matlab/New_eddy/fr_read_generic_data_file.m
+++ b/matlab/New_eddy/fr_read_generic_data_file.m
@@ -185,6 +185,11 @@ function [EngUnits,Header,tv,outStruct] = fr_read_generic_data_file(fileName,ass
                 opts.VariableOptions(dateColumnNum(2)).InputFormat = char(timeInputFormat{2});
             end
         end
+
+        % Force delimiter to be a comma for CSVs
+        if contains(fileName,'.csv')
+            opts.Delimiter = {','};
+        end
         
         % Set all the rows of interest to data type "double"
         % If colToKeep has two elements assume that those are indexes


### PR DESCRIPTION
When reading in a CSV, the new lines of code set the delimiter option to a comma. This is needed, for example, if the CSV contains a time stamp in the first column, and the time stamp is not enclosed in quotes. If the time stamp include colons as part of the time string, then the delimiter will be set to ':' using detectImportOptions.m